### PR TITLE
Resolving object relations on an implicit conversion might be too aggressive

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,19 +164,18 @@ conversion.  If we make it explicit, the example looks like this.
 import com.github.tarao.bullet.Monad
 
 val car: Car = ...
-val engine: Option[Engine] = Monad.run(car.toEngine)
+val engine: Option[Engine] = car.toEngine.run
 
 val cars: Seq[Car] = ...
-val engines: Seq[Engine] = Monad.run(cars.map(_.toEngine))
+val engines: Seq[Engine] = cars.map(_.toEngine).run
 ```
 
-It is `Monad.run()` which actually calls `HasA[].map()`.  Until then,
-the invocation of `HasA[].map()` is postponed inside the monad.  If
-`Monad.run()` receives multiple monads, it will organize them into an
+It is `run()` which actually calls `HasA[].map()`.  Until then, the
+invocation of `HasA[].map()` is postponed inside the monad.  If the
+receiver of `run()` is a list of monads, it will organize them into an
 argument of a single invocation of `HasA[].map()`.  (You may wonder
 how it is possible since each monad value has its own instance of
-`HasA[]`.  It is actually only the first one in the list to be used if
-`Monad.run()` receives multiple monads.)
+`HasA[]`.  It is actually only the first one in the list to be used.)
 
 ### Why is it a monad?
 
@@ -298,13 +297,13 @@ val enginedCars: Seq[CarWithEngine] = cars.map(_.withEngine)
 
 ## Default values <a name="default"></a>
 
-An `Option[]` return value of `Monad.run()` may be `None` if
-`HasA[].map()` returns an empty list.  In this case, you can provide a
-default value to ensure having some value returned.  This is done by
-providing an implicit value of `Monad.Default[]`.  If you provide a
-default value, the return value can be received without being wrapped
-by `Option[]`.  For example, the following code defines a default
-value for an `Engine`.
+An `Option[]` return value of `run()` may be `None` if `HasA[].map()`
+returns an empty list.  In this case, you can provide a default value
+to ensure having some value returned.  This is done by providing an
+implicit value of `Monad.Default[]`.  If you provide a default value,
+the return value can be received without being wrapped by `Option[]`.
+For example, the following code defines a default value for an
+`Engine`.
 
 ```scala
 implicit val defaultEngine: Monad.Default[Engine] =
@@ -315,14 +314,14 @@ val engine: Engine = car.toEngine
 ```
 
 In this case, note that **the implicit value must be visible in the
-scope where the invocation of `Monad.run()` or the implicit conversion
+scope where the invocation of `run()` or the implicit conversion
 occurs**.
 
 For `Join[]`, you should be careful that you have two choices of types
 to provide a default value, either `Result` or `Right` of
 `Join[Result, Key, Left, Right]`.  If you provide a default value for
-`Result`, then you will always get a value by `Monad.run()` on a
-single monad but still get some values lacked by `Monad.run()` on
+`Result`, then you will always get a value by `run()` on a
+single monad but still get some values lacked by `run()` on
 multiple monads.  You should provide a default value for `Right` to
 avoid this.  In this time, **the implicit value must be visible in the
 scope where the invoction of `Join.Monadic()` occurs**.

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ val hasEngine: HasA[Car, Engine] = ...
 
 The usage of `toEngine` is quite the same except that (1) you have to
 write a type of return value (`Option[Engine]` or `Seq[Engine]` in
-this case), (2) you don't need to `flatten`.
+this case), (2) you don't need to `flatten` anymore.
 
 ```scala
+import com.github.tarao.bullet.Implicits._
+
 val car: Car = ...
 val engine: Option[Engine] = car.toEngine
 
@@ -320,11 +322,19 @@ occurs**.
 For `Join[]`, you should be careful that you have two choices of types
 to provide a default value, either `Result` or `Right` of
 `Join[Result, Key, Left, Right]`.  If you provide a default value for
-`Result`, then you will always get a value by `run()` on a
-single monad but still get some values lacked by `run()` on
-multiple monads.  You should provide a default value for `Right` to
-avoid this.  In this time, **the implicit value must be visible in the
-scope where the invoction of `Join.Monadic()` occurs**.
+`Result`, then you will always get a value by `run()` on a single
+monad but still get some values lacked by `run()` on multiple monads.
+You should provide a default value for `Right` to avoid this.  In this
+time, **the implicit value must be visible in the scope where the
+invoction of `Join.Monadic()` occurs**.
+
+## An implicit conversion vs. an explicit run
+
+You may think that resolving object relations on an implicit
+conversion is too aggressive.  There is a way not to allow implicit
+conversions and force explicit `run()`s instead.  Only you have to do
+is not to `import com.github.bullet.Implicits._`.  Other things will
+work fine without this.
 
 ## License <a name="license"></a>
 

--- a/src/main/scala/com/github/tarao/bullet/Implicits.scala
+++ b/src/main/scala/com/github/tarao/bullet/Implicits.scala
@@ -1,8 +1,11 @@
 package com.github.tarao
 package bullet
 
+/** A trait to allow resolving monads on an implicit conversion. */
 trait Implicits {
   implicit val runOnImplicitConversion: Monad.RunOnImplicitConversion =
     new Monad.RunOnImplicitConversion
 }
+
+/** Implicits to allow resolving monads on an implicit conversion. */
 object Implicits extends Implicits

--- a/src/main/scala/com/github/tarao/bullet/Implicits.scala
+++ b/src/main/scala/com/github/tarao/bullet/Implicits.scala
@@ -1,0 +1,8 @@
+package com.github.tarao
+package bullet
+
+trait Implicits {
+  implicit val runOnImplicitConversion: Monad.RunOnImplicitConversion =
+    new Monad.RunOnImplicitConversion
+}
+object Implicits extends Implicits

--- a/src/main/scala/com/github/tarao/bullet/Monad.scala
+++ b/src/main/scala/com/github/tarao/bullet/Monad.scala
@@ -194,21 +194,26 @@ object Monad {
 
   /** A type tag to forbid implicit conversion on a list of monads.
     *
-    * It forbids an implicit conversion from
-    * `Seq[Monad[SingleValue[T]]]` to `Seq[T]`.  This is useful when
-    * you provide no `Resolve.run` which resolves multiple values all
-    * together but provide one which resolves each element separately
-    * (via `Seq.map` for example) and want to prevent users from
-    * expecting that they can be resolved at once.
+    * It forbids an conversion from `Seq[Monad[SingleValue[T]]]` to
+    * `Seq[T]`.  This is useful when you provide no `Resolve.run`
+    * which resolves multiple values all together but provide one
+    * which resolves each element separately (via `Seq.map` for
+    * example) and want to prevent users from expecting that they can
+    * be resolved at once.
     */
   case class SingleValue[T](value: T) extends AnyVal
   object SingleValue {
     // $COVERAGE-OFF$
-    implicit def runToSingleValueIsForbidden[R, M](m: Seq[M])(implicit
+    implicit def runToSingleValueIsProhibited[R, M](m: Seq[M])(implicit
       guard: RunOnImplicitConversion,
       monad: M <:< Monad[SingleValue[R]],
       check: IsConcreteType[M]
     ): Seq[SingleValue[R]] = sys.error("unexpected")
+    implicit def runnableOfSingleValueIsProhibited[R, M, S](ms: S)(implicit
+      seq: S => Seq[M],
+      monad: M <:< Monad[R],
+      check: IsConcreteType[M]
+    ): Runnable[R, M, S] = sys.error("unexpected")
     // $COVERAGE-ON$
 
     implicit def run[R, M](m: M)(implicit

--- a/src/main/scala/com/github/tarao/bullet/Monad.scala
+++ b/src/main/scala/com/github/tarao/bullet/Monad.scala
@@ -137,7 +137,8 @@ object Monad {
   ): Seq[R] = run(Seq(m)).flatten
 
   /** A type class to run `Monad[]`s all together */
-  implicit class Runnable[R, M](ms: Seq[M])(implicit
+  implicit class Runnable[R, M, S](ms: S)(implicit
+    seq: S => Seq[M],
     monad: M <:< Monad[R],
     check: IsConcreteType[M]
   ) {
@@ -148,11 +149,11 @@ object Monad {
   }
 
   /** A type class to run each element of `Monad[]`s separately. */
-  class Divergent[R](ms: Seq[Monad[R]]) {
+  class Divergent[R](val ms: Seq[Monad[R]]) extends AnyVal {
     def run(): Seq[R] = ms.map(_.run).flatten
   }
-  implicit class Divergeable[R](ms: Seq[Monad[R]]) {
-    def diverge(): Divergent[R] = new Divergent(ms)
+  implicit class Divergeable[R, S](ms: S)(implicit seq: S => Seq[Monad[R]]) {
+    def diverge(): Divergent[R] = new Divergent(seq(ms))
   }
 
   class Fallback[T] {

--- a/src/main/scala/com/github/tarao/bullet/Monad.scala
+++ b/src/main/scala/com/github/tarao/bullet/Monad.scala
@@ -36,7 +36,7 @@ object Monad {
 
   /** A class to create a monad instance from an object of the result type. */
   case class Unit[R](value: R) extends Sig[R, Null, Null, Null] {
-    protected[bullet] def run(ms: Seq[Unit[R]]): Seq[R] = ms.map(_.value)
+    protected[Monad] def run(ms: Seq[Unit[R]]): Seq[R] = ms.map(_.value)
   }
 
   /** A class to define a resolution from source values to target values.
@@ -44,7 +44,7 @@ object Monad {
     * Override `run` to define a concrete resolution.
     */
   abstract case class Resolve[R, Q](value: Q) extends Sig[R, Q, Null, Null] {
-    protected[bullet] def run(ms: Seq[Resolve[R, Q]]): Seq[R]
+    protected[Monad] def run(ms: Seq[Resolve[R, Q]]): Seq[R]
   }
 
   case class FlatMapped[R, Q, N, M](
@@ -55,7 +55,7 @@ object Monad {
     monad2: N <:< Monad[R],
     check2: IsConcreteType[N]
   ) extends Sig[R, Q, N, M] {
-    protected[bullet] def run(ms: Seq[FlatMapped[R, Q, N, M]]): Seq[R] = {
+    protected[Monad] def run(ms: Seq[FlatMapped[R, Q, N, M]]): Seq[R] = {
       val fs = ms.map(_.f)
       val mapped = Internal.run(ms.map { m => monad1(m.m) })
       Internal.run((fs, mapped).zipped.map { (f, m) => monad2(f(m)) })

--- a/src/test/scala/com/github/tarao/bullet/ExplicitSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/ExplicitSpec.scala
@@ -1,0 +1,55 @@
+package com.github.tarao
+package bullet
+
+import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
+
+class ExplicitSpec extends FunSpec with Matchers
+    with OptionValues with Inside with Inspectors {
+  import Example._
+
+  describe("Monad") {
+    it("should not run implicitly") {
+      val m1 = Monad.Unit(Engine(1001L, 3L))
+      assertTypeError("val engine: Option[Engine] = m1")
+
+      val m2 = ResolveEngine(Car(3L, "foo"))
+      assertTypeError("val engine: Option[Engine] = m1")
+
+      val m3 = Monad.Unit(Engine(1001L, 3L)).map(identity)
+      assertTypeError("val engine: Option[Engine] = m3")
+
+      val m4 = Monad.Unit(Engine(1001L, 3L)).flatMap { e =>
+        ResolveEngine(Car(3L, "foo"))
+      }
+      assertTypeError("val engine: Option[Engine] = m4")
+
+      val ms1 = Seq(
+        Monad.Unit(Engine(1001L, 3L)),
+        Monad.Unit(Engine(1002L, 2L)),
+        Monad.Unit(Engine(1003L, 5L))
+      )
+      assertTypeError("val engines: Seq[Engine] = ms1")
+
+      val ms2 = Seq(
+        ResolveEngine(Car(3L, "foo")),
+        ResolveEngine(Car(2L, "bar")),
+        ResolveEngine(Car(5L, "baz"))
+      )
+      assertTypeError("val engines: Seq[Engine] = ms2")
+
+      val ms3 = Seq(
+        Monad.Unit(Engine(1001L, 3L)),
+        Monad.Unit(Engine(1002L, 2L)),
+        Monad.Unit(Engine(1003L, 5L))
+      ).map { m => m.map(identity) }
+      assertTypeError("val engines: Seq[Engine] = ms3")
+
+      val ms4 = Seq(
+        Monad.Unit(Engine(1001L, 3L)),
+        Monad.Unit(Engine(1002L, 2L)),
+        Monad.Unit(Engine(1003L, 5L))
+      ).map { m => m.flatMap { e => ResolveEngine(Car(e.carId, "dummy")) } }
+      assertTypeError("val engines: Seq[Engine] = ms4")
+    }
+  }
+}

--- a/src/test/scala/com/github/tarao/bullet/ExplicitSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/ExplicitSpec.scala
@@ -51,5 +51,65 @@ class ExplicitSpec extends FunSpec with Matchers
       ).map { m => m.flatMap { e => ResolveEngine(Car(e.carId, "dummy")) } }
       assertTypeError("val engines: Seq[Engine] = ms4")
     }
+
+    it("should run explicitly") {
+      val m1 = Monad.Unit(Engine(1001L, 3L))
+      m1.run shouldBe Some(Engine(1001L, 3L))
+
+      val m2 = ResolveEngine(Car(3L, "foo"))
+      m2.run shouldBe Some(Engine(1003L, 3L))
+
+      val m3 = Monad.Unit(Engine(1001L, 3L)).map(identity)
+      m3.run shouldBe Some(Engine(1001L, 3L))
+
+      val m4 = Monad.Unit(Engine(1001L, 3L)).flatMap { e =>
+        ResolveEngine(Car(3L, "foo"))
+      }
+      m4.run shouldBe Some(Engine(1003L, 3L))
+
+      val ms1 = Seq(
+        Monad.Unit(Engine(1001L, 3L)),
+        Monad.Unit(Engine(1002L, 2L)),
+        Monad.Unit(Engine(1003L, 5L))
+      )
+      ms1.run should contain only  (
+        Engine(1001L, 3L),
+        Engine(1002L, 2L),
+        Engine(1003L, 5L)
+      )
+
+      val ms2 = Seq(
+        ResolveEngine(Car(3L, "foo")),
+        ResolveEngine(Car(2L, "bar")),
+        ResolveEngine(Car(5L, "baz"))
+      )
+      ms2.run should contain only (
+        Engine(1003L, 3L),
+        Engine(1002L, 2L),
+        Engine(1005L, 5L)
+      )
+
+      val ms3 = Seq(
+        Monad.Unit(Engine(1001L, 3L)),
+        Monad.Unit(Engine(1002L, 2L)),
+        Monad.Unit(Engine(1003L, 5L))
+      ).map { m => m.map(identity) }
+      ms3.run should contain only (
+        Engine(1001L, 3L),
+        Engine(1002L, 2L),
+        Engine(1003L, 5L)
+      )
+
+      val ms4 = Seq(
+        Monad.Unit(Engine(1001L, 3L)),
+        Monad.Unit(Engine(1002L, 2L)),
+        Monad.Unit(Engine(1003L, 5L))
+      ).map { m => m.flatMap { e => ResolveEngine(Car(e.carId, "dummy")) } }
+      ms4.run should contain only  (
+        Engine(1003L, 3L),
+        Engine(1002L, 2L),
+        Engine(1005L, 5L)
+      )
+    }
   }
 }

--- a/src/test/scala/com/github/tarao/bullet/HasASpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/HasASpec.scala
@@ -30,15 +30,15 @@ class HasASpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        val engine1 = Monad.run(car.toEngine)
+        val engine1 = car.toEngine.run
         engine1 shouldBe Some(Engine(1001L, 3L))
 
-        val engine2 = Monad.run(for {
+        val engine2 = (for {
           engine <- car.toEngine
         } yield {
           engine shouldBe Engine(1001L, 3L)
           engine
-        })
+        }).run
         engine1 shouldBe Some(Engine(1001L, 3L))
       }
     }
@@ -68,20 +68,20 @@ class HasASpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        val engine1 = Monad.run(car.toEngine)
-        val crankshaft1 = engine1.flatMap { e => Monad.run(e.toCrankshaft) }
+        val engine1 = car.toEngine.run
+        val crankshaft1 = engine1.flatMap { e => e.toCrankshaft.run }
         crankshaft1 shouldBe Some(Crankshaft(1001L))
 
-        val crankshaft2 = Monad.run(car.toEngine.flatMap(_.toCrankshaft))
+        val crankshaft2 = car.toEngine.flatMap(_.toCrankshaft).run
         crankshaft2 shouldBe Some(Crankshaft(1001L))
 
-        val crankshaft3 = Monad.run(for {
+        val crankshaft3 = (for {
           engine <- car.toEngine
           crankshaft <- engine.toCrankshaft
         } yield {
           crankshaft shouldBe Crankshaft(1001L)
           crankshaft
-        })
+        }).run
         crankshaft3 shouldBe Some(Crankshaft(1001L))
       }
     }
@@ -118,18 +118,18 @@ class HasASpec extends FunSpec with Matchers
 
       // // by explicit run
       locally {
-        var engines1 = Monad.run(cars.map(_.toEngine))
+        var engines1 = cars.map(_.toEngine).run
         engines1 should contain only (
           Engine(1001L, 3L),
           Engine(1003L, 5L)
         )
 
-        val engines2 = Monad.run(cars.map { car => for {
+        val engines2 = cars.map { car => for {
           engine <- car.toEngine
         } yield {
           engine shouldBe map(engine.id)
           engine
-        } })
+        } }.run
         engines2 should contain only (
           Engine(1001L, 3L),
           Engine(1003L, 5L)
@@ -166,20 +166,20 @@ class HasASpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        var engines1 = Monad.run(cars.map(_.toEngine))
-        var crankshafts1 = Monad.run(engines1.map(_.toCrankshaft))
+        var engines1 = cars.map(_.toEngine).run
+        var crankshafts1 = engines1.map(_.toCrankshaft).run
         crankshafts1 should contain only (
           Crankshaft(1001L),
           Crankshaft(1003L)
         )
 
-        val crankshafts2 = Monad.run(cars.map { car => for {
+        val crankshafts2 = cars.map { car => for {
           engine <- car.toEngine
           crankshaft <- engine.toCrankshaft
         } yield {
           crankshaft shouldBe Crankshaft(engine.id)
           crankshaft
-        } })
+        } }.run
         crankshafts2 should contain only (
           Crankshaft(1001L),
           Crankshaft(1003L)

--- a/src/test/scala/com/github/tarao/bullet/HasASpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/HasASpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
 
 class HasASpec extends FunSpec with Matchers
     with OptionValues with Inside with Inspectors {
+  import Implicits._
   import Example._
 
   describe("HasA") {

--- a/src/test/scala/com/github/tarao/bullet/JoinSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/JoinSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
 
 class JoinSpec extends FunSpec with Matchers
     with OptionValues with Inside with Inspectors {
+  import Implicits._
   import Example._
 
   describe("Join") {

--- a/src/test/scala/com/github/tarao/bullet/JoinSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/JoinSpec.scala
@@ -30,15 +30,15 @@ class JoinSpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        val car1 = Monad.run(car.withEngine)
+        val car1 = car.withEngine.run
         car1 shouldBe Some((Car(3L, "foo"), Engine(1001L, 3L)))
 
-        val car2 = Monad.run(for {
+        val car2 = (for {
           car <- car.withEngine
         } yield {
           car shouldBe (Car(3L, "foo"), Engine(1001L, 3L))
           car
-        })
+        }).run
         car2 shouldBe Some((Car(3L, "foo"), Engine(1001L, 3L)))
       }
     }
@@ -74,20 +74,20 @@ class JoinSpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        val car1 = Monad.run(car.withEngine)
-        val car2 = car1.flatMap { car => Monad.run(car.withWheels) }
+        val car1 = car.withEngine.run
+        val car2 = car1.flatMap { car => car.withWheels.run }
         car2 shouldBe Some((Car(3L, "foo"), Engine(1001L, 3L), wheels(3L)))
 
-        val car3 = Monad.run(car.withEngine.flatMap(_.withWheels))
+        val car3 = car.withEngine.flatMap(_.withWheels).run
         car3 shouldBe Some((Car(3L, "foo"), Engine(1001L, 3L), wheels(3L)))
 
-        val car4 = Monad.run(for {
+        val car4 = (for {
           car <- car.withEngine
           car <- car.withWheels
         } yield {
           car shouldBe (Car(3L, "foo"), Engine(1001L, 3L), wheels(3L))
           car
-        })
+        }).run
         car4 shouldBe Some((Car(3L, "foo"), Engine(1001L, 3L), wheels(3L)))
       }
     }
@@ -124,18 +124,18 @@ class JoinSpec extends FunSpec with Matchers
 
       // // by explicit run
       locally {
-        var cars1 = Monad.run(cars.map(_.withEngine))
+        var cars1 = cars.map(_.withEngine).run
         cars1 should contain only (
           (Car(3L, "foo"), Engine(1001L, 3L)),
           (Car(5L, "baz"), Engine(1003L, 5L))
         )
 
-        val cars2 = Monad.run(cars.map { car => for {
+        val cars2 = cars.map { car => for {
           car <- car.withEngine
         } yield {
           car._2 shouldBe map(car._2.id)
           car
-        } })
+        } }.run
         cars2 should contain only (
           (Car(3L, "foo"), Engine(1001L, 3L)),
           (Car(5L, "baz"), Engine(1003L, 5L))
@@ -181,16 +181,16 @@ class JoinSpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        var cars1 = Monad.run(cars.map(_.withEngine))
-        var cars2 = Monad.run(cars1.map(_.withWheels))
+        var cars1 = cars.map(_.withEngine).run
+        var cars2 = cars1.map(_.withWheels).run
         cars2 should contain only (filtered.map { car =>
           (car, engines(car.id), wheels(car.id))
         }: _*)
 
-        val cars3 = Monad.run(cars.map { car => for {
+        val cars3 = cars.map { car => for {
           car <- car.withEngine
           car <- car.withWheels
-        } yield(car) })
+        } yield(car) }.run
         cars3 should contain only (filtered.map { car =>
           (car, engines(car.id), wheels(car.id))
         }: _*)
@@ -227,15 +227,15 @@ class JoinSpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        val car1 = Monad.run(car.withEngine)
+        val car1 = car.withEngine.run
         car1 shouldBe Some((Car(2L, "bar"), Engine(0L, 0L)))
 
-        val car2 = Monad.run(for {
+        val car2 = (for {
           car <- car.withEngine
         } yield {
           car shouldBe (Car(2L, "bar"), Engine(0L, 0L))
           car
-        })
+        }).run
         car2 shouldBe Some((Car(2L, "bar"), Engine(0L, 0L)))
       }
     }
@@ -271,20 +271,20 @@ class JoinSpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        val car1 = Monad.run(car.withEngine)
-        val car2 = car1.flatMap { car => Monad.run(car.withWheels) }
+        val car1 = car.withEngine.run
+        val car2 = car1.flatMap { car => car.withWheels.run }
         car2 shouldBe Some((Car(2L, "bar"), Engine(0L, 0L), wheels(2L)))
 
-        val car3 = Monad.run(car.withEngine.flatMap(_.withWheels))
+        val car3 = car.withEngine.flatMap(_.withWheels).run
         car3 shouldBe Some((Car(2L, "bar"), Engine(0L, 0L), wheels(2L)))
 
-        val car4 = Monad.run(for {
+        val car4 = (for {
           car <- car.withEngine
           car <- car.withWheels
         } yield {
           car shouldBe (Car(2L, "bar"), Engine(0L, 0L), wheels(2L))
           car
-        })
+        }).run
         car4 shouldBe Some((Car(2L, "bar"), Engine(0L, 0L), wheels(2L)))
       }
     }
@@ -324,19 +324,19 @@ class JoinSpec extends FunSpec with Matchers
 
       // // by explicit run
       locally {
-        var cars1 = Monad.run(cars.map(_.withEngine))
+        var cars1 = cars.map(_.withEngine).run
         cars1 should contain only (
           (Car(3L, "foo"), Engine(1001L, 3L)),
           (Car(2L, "bar"), Engine(0L, 0L)),
           (Car(5L, "baz"), Engine(1003L, 5L))
         )
 
-        val cars2 = Monad.run(cars.map { car => for {
+        val cars2 = cars.map { car => for {
           car <- car.withEngine
         } yield {
           car._2 shouldBe map(car._2.id)
           car
-        } })
+        } }.run
         cars2 should contain only (
           (Car(3L, "foo"), Engine(1001L, 3L)),
           (Car(2L, "bar"), Engine(0L, 0L)),
@@ -381,16 +381,16 @@ class JoinSpec extends FunSpec with Matchers
 
       // by explicit run
       locally {
-        var cars1 = Monad.run(cars.map(_.withEngine))
-        var cars2 = Monad.run(cars1.map(_.withWheels))
+        var cars1 = cars.map(_.withEngine).run
+        var cars2 = cars1.map(_.withWheels).run
         cars2 should contain only (filtered.map { car =>
           (car, engines(car.id), wheels(car.id))
         }: _*)
 
-        val cars3 = Monad.run(cars.map { car => for {
+        val cars3 = cars.map { car => for {
           car <- car.withEngine
           car <- car.withWheels
-        } yield(car) })
+        } yield(car) }.run
         cars3 should contain only (filtered.map { car =>
           (car, engines(car.id), wheels(car.id))
         }: _*)

--- a/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
@@ -1351,21 +1351,19 @@ class MonadSpec extends FunSpec with Matchers
         engine shouldBe Some(Engine(1001L, 3L))
 
         val ms1: Seq[Monad.Unit[Engine]] = Seq(Monad.Unit(Engine(1001L, 3L)))
-        val engines1: Seq[Engine] = Monad.Divergent.run(ms1)
+        val engines1: Seq[Engine] = ms1.diverge.run
         engines1 should contain only Engine(1001L, 3L)
 
         val ms2 = Array(Monad.Unit(Engine(1001L, 3L))).toSeq
-        val engines2: Seq[Engine] = Monad.Divergent.run(ms2)
+        val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe Array(Engine(1001L, 3L))
       }
 
       locally { // Resolve
-        val engine1: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(3L, "foo")))
+        val engine1: Option[Engine] = ResolveEngine(Car(3L, "foo")).run
         engine1 shouldBe Some(Engine(1003L, 3L))
 
-        val engine2: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(2L, "bar")))
+        val engine2: Option[Engine] = ResolveEngine(Car(2L, "bar")).run
         engine2 shouldBe None
 
         val ms1 = Seq(
@@ -1373,7 +1371,7 @@ class MonadSpec extends FunSpec with Matchers
           ResolveEngine(Car(2L, "bar")),
           ResolveEngine(Car(5L, "baz"))
         )
-        val engines1: Seq[Engine] = Monad.Divergent.run(ms1)
+        val engines1: Seq[Engine] = ms1.diverge.run
         engines1 should contain only (Engine(1003L, 3L), Engine(1005L, 5L))
 
         val ms2 = Array(
@@ -1381,54 +1379,51 @@ class MonadSpec extends FunSpec with Matchers
           ResolveEngine(Car(2L, "bar")),
           ResolveEngine(Car(5L, "baz"))
         ).toSeq
-        val engines2: Seq[Engine] = Monad.Divergent.run(ms2)
+        val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe Array(Engine(1003L, 3L), Engine(1005L, 5L))
       }
 
       locally { // mapped
-        val engine1: Option[Engine] =
-          Monad.Divergent.run(Monad.Unit(Engine(1001L, 3L)).map { e =>
-            Engine(1002L, 5L)
-          })
+        val engine1: Option[Engine] = (Monad.Unit(Engine(1001L, 3L)).map { e =>
+          Engine(1002L, 5L)
+        }).run
         engine1 shouldBe Some(Engine(1002L, 5L))
 
-        val engine2: Option[Engine] = Monad.Divergent.run(for {
+        val engine2: Option[Engine] = (for {
           e <- Monad.Unit(Engine(1001L, 3L))
-        } yield(Engine(1002L, 5L)))
+        } yield(Engine(1002L, 5L))).run
         engine2 shouldBe Some(Engine(1002L, 5L))
 
-        val engine3: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(3L, "foo")).map { e =>
-            Engine(1002L, 5L)
-          })
+        val engine3: Option[Engine] = ResolveEngine(Car(3L, "foo")).map { e =>
+          Engine(1002L, 5L)
+        }.run
         engine3 shouldBe Some(Engine(1002L, 5L))
 
-        val engine4: Option[Engine] = Monad.Divergent.run(for {
+        val engine4: Option[Engine] = (for {
           e <- ResolveEngine(Car(3L, "foo"))
-        } yield(Engine(1002L, 5L)))
+        } yield(Engine(1002L, 5L))).run
         engine4 shouldBe Some(Engine(1002L, 5L))
 
-        val engine5: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(2L, "bar")).map { e =>
-            Engine(1002L, 5L)
-          })
+        val engine5: Option[Engine] = ResolveEngine(Car(2L, "bar")).map { e =>
+          Engine(1002L, 5L)
+        }.run
         engine5 shouldBe None
 
-        val engine6: Option[Engine] = Monad.Divergent.run(for {
+        val engine6: Option[Engine] = (for {
           e <- ResolveEngine(Car(2L, "bar"))
-        } yield(Engine(1002L, 5L)))
+        } yield(Engine(1002L, 5L))).run
         engine6 shouldBe None
 
         val ms1 = Seq(Monad.Unit(Engine(1001L, 3L)).map { e =>
           Engine(1002L, 5L)
         })
-        val engines1: Seq[Engine] = Monad.Divergent.run(ms1)
+        val engines1: Seq[Engine] = ms1.diverge.run
         engines1 shouldBe Seq(Engine(1002L, 5L))
 
         val ms2 = Seq(for {
           e <- Monad.Unit(Engine(1001L, 3L))
         } yield(Engine(1002L, 5L)))
-        val engines2: Seq[Engine] = Monad.Divergent.run(ms2)
+        val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe Seq(Engine(1002L, 5L))
 
         val ms3 = Seq(
@@ -1436,7 +1431,7 @@ class MonadSpec extends FunSpec with Matchers
           ResolveEngine(Car(2L, "bar")),
           ResolveEngine(Car(5L, "baz"))
         ).map { m => m.map { e => Engine(e.id + 1, e.carId + 1) } }
-        val engines3: Seq[Engine] = Monad.Divergent.run(ms3)
+        val engines3: Seq[Engine] = ms3.diverge.run
         engines3 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
 
         val ms4 = Seq(
@@ -1446,70 +1441,70 @@ class MonadSpec extends FunSpec with Matchers
         ).map { car => for {
           e <- ResolveEngine(car)
         } yield(Engine(e.id + 1, e.carId + 1)) }
-        val engines4: Seq[Engine] = Monad.Divergent.run(ms4)
+        val engines4: Seq[Engine] = ms4.diverge.run
         engines4 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
       }
 
       locally { // flat-mapped
         val engine1: Option[Engine] =
-          Monad.Divergent.run(Monad.Unit(Engine(1001L, 3L)).flatMap { e =>
+          Monad.Unit(Engine(1001L, 3L)).flatMap { e =>
             Monad.Unit(Engine(1002L, 5L))
-          })
+          }.run
         engine1 shouldBe Some(Engine(1002L, 5L))
 
-        val engine2: Option[Engine] = Monad.Divergent.run(for {
+        val engine2: Option[Engine] = (for {
           e <- Monad.Unit(Engine(1001L, 3L))
           e <- Monad.Unit(Engine(1002L, 5L))
-        } yield(e))
+        } yield(e)).run
         engine2 shouldBe Some(Engine(1002L, 5L))
 
         val engine3: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(3L, "foo")).flatMap { e =>
+          (ResolveEngine(Car(3L, "foo")).flatMap { e =>
             Monad.Unit(Engine(1002L, 5L))
-          })
+          }).run
         engine3 shouldBe Some(Engine(1002L, 5L))
 
-        val engine4: Option[Engine] = Monad.Divergent.run(for {
+        val engine4: Option[Engine] = (for {
           e <- ResolveEngine(Car(3L, "foo"))
           e <- Monad.Unit(Engine(1002L, 5L))
-        } yield(e))
+        } yield(e)).run
         engine4 shouldBe Some(Engine(1002L, 5L))
 
         val engine5: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(3L, "foo")).flatMap { e =>
+          ResolveEngine(Car(3L, "foo")).flatMap { e =>
             ResolveEngine(Car(5L, "baz"))
-          })
+          }.run
         engine5 shouldBe Some(Engine(1005L, 5L))
 
-        val engine6: Option[Engine] = Monad.Divergent.run(for {
+        val engine6: Option[Engine] = (for {
           e <- ResolveEngine(Car(3L, "foo"))
           e <- ResolveEngine(Car(5L, "baz"))
-        } yield(e))
+        } yield(e)).run
         engine6 shouldBe Some(Engine(1005L, 5L))
 
         val engine7: Option[Engine] =
-          Monad.Divergent.run(ResolveEngine(Car(3L, "foo")).flatMap { e =>
+          ResolveEngine(Car(3L, "foo")).flatMap { e =>
             ResolveEngine(Car(2L, "bar"))
-          })
+          }.run
         engine7 shouldBe None
 
-        val engine8: Option[Engine] = Monad.Divergent.run(for {
+        val engine8: Option[Engine] = (for {
           e <- ResolveEngine(Car(3L, "foo"))
           e <- ResolveEngine(Car(2L, "bar"))
-        } yield(e))
+        } yield(e)).run
         engine8 shouldBe None
 
         val ms1 = Seq(Monad.Unit(Engine(1001L, 3L)).flatMap { e =>
           Monad.Unit(Engine(1002L, 5L))
         })
-        val engines1: Seq[Engine] = Monad.Divergent.run(ms1)
+        val engines1: Seq[Engine] = ms1.diverge.run
         engines1 shouldBe Seq(Engine(1002L, 5L))
 
         val ms2 = Seq(for {
           e <- Monad.Unit(Engine(1001L, 3L))
           e <- Monad.Unit(Engine(1002L, 5L))
         } yield(e))
-        val engines2: Seq[Engine] = Monad.Divergent.run(ms2)
+        val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe Seq(Engine(1002L, 5L))
 
         val ms3 = Seq(
@@ -1517,7 +1512,7 @@ class MonadSpec extends FunSpec with Matchers
           ResolveEngine(Car(2L, "bar")),
           ResolveEngine(Car(5L, "baz"))
         ).map(_.flatMap { e => Monad.Unit(Engine(e.id + 1, e.carId + 1)) })
-        val engines3: Seq[Engine] = Monad.Divergent.run(ms3)
+        val engines3: Seq[Engine] = ms3.diverge.run
         engines3 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
 
         val ms4 = Seq(
@@ -1528,7 +1523,7 @@ class MonadSpec extends FunSpec with Matchers
           e <- ResolveEngine(car)
           e <- Monad.Unit(Engine(e.id + 1, e.carId + 1))
         } yield(e) }
-        val engines4: Seq[Engine] = Monad.Divergent.run(ms4)
+        val engines4: Seq[Engine] = ms4.diverge.run
         engines4 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
 
         val ms5 = Seq(
@@ -1536,7 +1531,7 @@ class MonadSpec extends FunSpec with Matchers
           ResolveEngine(Car(2L, "bar")),
           ResolveEngine(Car(5L, "baz"))
         ).map(_.flatMap { e => ResolveEngine(Car(e.carId+2, "dummy")) })
-        val engines5: Seq[Engine] = Monad.Divergent.run(ms5)
+        val engines5: Seq[Engine] = ms5.diverge.run
         engines5 shouldBe Array(Engine(1005L, 5L), Engine(1007L, 7L))
 
         val ms6 = Seq(
@@ -1547,325 +1542,155 @@ class MonadSpec extends FunSpec with Matchers
           e <- ResolveEngine(car)
           e <- ResolveEngine(Car(e.carId+2, "dummy"))
         } yield(e) }
-        val engines6: Seq[Engine] = Monad.Divergent.run(ms6)
+        val engines6: Seq[Engine] = ms6.diverge.run
         engines6 shouldBe Array(Engine(1005L, 5L), Engine(1007L, 7L))
       }
 
       locally { // empty list
         val ms1: Seq[Monad.Unit[Engine]] = Seq.empty
-        val engines1: Seq[Engine] = Monad.Divergent.run(ms1)
+        val engines1: Seq[Engine] = ms1.diverge.run
         engines1 shouldBe empty
 
         val ms2 = ms1.map { m => m.map { e => Engine(1002L, 5L) } }
-        val engines2: Seq[Engine] = Monad.Divergent.run(ms2)
+        val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe empty
 
         val ms3 = ms1.map { m => for (e <- m) yield(Engine(1002L, 5L)) }
-        val engines3: Seq[Engine] = Monad.Divergent.run(ms3)
+        val engines3: Seq[Engine] = ms3.diverge.run
         engines3 shouldBe empty
 
         val ms4 = ms1.map { m => m.flatMap {
           e => Monad.Unit(Engine(1002L, 5L))
         } }
-        val engines4: Seq[Engine] = Monad.Divergent.run(ms4)
+        val engines4: Seq[Engine] = ms4.diverge.run
         engines4 shouldBe empty
 
         val ms5 = ms1.map { m => for {
           e <- m
           e <- Monad.Unit(Engine(1002L, 5L))
         } yield(e) }
-        val engines5: Seq[Engine] = Monad.Divergent.run(ms5)
+        val engines5: Seq[Engine] = ms5.diverge.run
         engines5 shouldBe empty
 
         val ms6 = ms1.map { m => m.flatMap {
           e => ResolveEngine(Car(3L, "foo"))
         } }
-        val engines6: Seq[Engine] = Monad.Divergent.run(ms6)
+        val engines6: Seq[Engine] = ms6.diverge.run
         engines6 shouldBe empty
 
         val ms7 = ms1.map { m => for {
           e <- m
           e <- ResolveEngine(Car(3L, "foo"))
         } yield(e) }
-        val engines7: Seq[Engine] = Monad.Divergent.run(ms7)
+        val engines7: Seq[Engine] = ms7.diverge.run
         engines7 shouldBe empty
 
         val ms8 = Seq(Car(2L, "bar")).map(ResolveEngine(_))
-        val engines8: Seq[Engine] = Monad.Divergent.run(ms8)
+        val engines8: Seq[Engine] = ms8.diverge.run
         engines8 shouldBe empty
 
         val ms9 = ms8.map { m => m.map { e => Engine(1002L, 5L) } }
-        val engines9: Seq[Engine] = Monad.Divergent.run(ms9)
+        val engines9: Seq[Engine] = ms9.diverge.run
         engines9 shouldBe empty
 
         val ms10 = ms8.map { m => for (e <- m) yield(Engine(1002L, 5L)) }
-        val engines10: Seq[Engine] = Monad.Divergent.run(ms10)
+        val engines10: Seq[Engine] = ms10.diverge.run
         engines10 shouldBe empty
 
         val ms11 = ms8.map { m => m.flatMap {
           e => Monad.Unit(Engine(1002L, 5L))
         } }
-        val engines11: Seq[Engine] = Monad.Divergent.run(ms11)
+        val engines11: Seq[Engine] = ms11.diverge.run
         engines11 shouldBe empty
 
         val ms12 = ms8.map { m => for {
           e <- m
           e <- Monad.Unit(Engine(1002L, 5L))
         } yield(e) }
-        val engines12: Seq[Engine] = Monad.Divergent.run(ms12)
+        val engines12: Seq[Engine] = ms12.diverge.run
         engines12 shouldBe empty
 
         val ms13 = ms8.map { m => m.flatMap {
           e => ResolveEngine(Car(3L, "foo"))
         } }
-        val engines13: Seq[Engine] = Monad.Divergent.run(ms13)
+        val engines13: Seq[Engine] = ms13.diverge.run
         engines13 shouldBe empty
 
         val ms14 = ms8.map { m => for {
           e <- m
           e <- ResolveEngine(Car(3L, "foo"))
         } yield(e) }
-        val engines14: Seq[Engine] = Monad.Divergent.run(ms14)
+        val engines14: Seq[Engine] = ms14.diverge.run
         engines14 shouldBe empty
       }
 
-      locally { // flatten option lists
-        locally {
-          val ms1 = Monad.Unit(Seq(Engine(1001L, 3L)))
-          val engines1: Option[Seq[Engine]] = Monad.Divergent.run(ms1)
-          engines1 shouldBe Some(Seq(Engine(1001L, 3L)))
-
-          val engines2: Seq[Engine] = Monad.Divergent.flatten(ms1)
-          engines2 should contain only Engine(1001L, 3L)
-        }
-
-        locally {
-          val ms1 = ResolveWheels(Car(3L, "foo"))
-          val wheels1: Option[Seq[Wheel]] = Monad.Divergent.run(ms1)
-          wheels1 shouldBe Some(Seq(
-            Wheel(1, 3L),
-            Wheel(2, 3L),
-            Wheel(3, 3L),
-            Wheel(4, 3L)
-          ))
-
-          val wheels2: Seq[Wheel] = Monad.Divergent.flatten(ms1)
-          wheels2 should contain only (
-            Wheel(1, 3L),
-            Wheel(2, 3L),
-            Wheel(3, 3L),
-            Wheel(4, 3L)
-          )
-
-          val wheels3: Option[Seq[Wheel]] =
-            Monad.Divergent.run(
-              ResolveWheels(Car(3L, "foo")).map(_.map { wheel =>
-                Wheel(wheel.position, wheel.carId + 1)
-              }))
-          wheels3 shouldBe Some(Seq(
-            Wheel(1, 4L),
-            Wheel(2, 4L),
-            Wheel(3, 4L),
-            Wheel(4, 4L)
-          ))
-
-          val wheels4: Seq[Wheel] =
-            Monad.Divergent.flatten(
-              ResolveWheels(Car(3L, "foo")).map(_.map { wheel =>
-                Wheel(wheel.position, wheel.carId + 1)
-              }))
-          wheels4 should contain only (
-            Wheel(1, 4L),
-            Wheel(2, 4L),
-            Wheel(3, 4L),
-            Wheel(4, 4L)
-          )
-        }
-      }
-
-      locally { // flatten nested list
-        locally {
-          val ms1 = Seq(Monad.Unit(Seq(Engine(1001L, 3L))))
-          val engines1: Seq[Seq[Engine]] = Monad.Divergent.run(ms1)
-          engines1 should contain only Seq(Engine(1001L, 3L))
-
-          val engines2: Seq[Engine] = Monad.Divergent.flatten(ms1)
-          engines2 should contain only Engine(1001L, 3L)
-
-          val ms3 = Array(Monad.Unit(Array(Engine(1001L, 3L)))).toSeq
-          val engines3: Seq[Array[Engine]] = Monad.Divergent.run(ms3)
-          engines3 should contain only Array(Engine(1001L, 3L))
-
-          val engines4: Seq[Engine] = Monad.Divergent.flatten(ms3)
-          engines4 should contain only Engine(1001L, 3L)
-        }
-
-        locally {
-          val ms1 = Seq(
-            Car(3L, "foo"),
-            Car(2L, "bar"),
-            Car(5L, "baz")
-          ).map { car => ResolveWheels(car) }
-          val wheels1: Seq[Seq[Wheel]] = Monad.Divergent.run(ms1)
-          wheels1 should contain only (
-            Seq(Wheel(1, 3L), Wheel(2, 3L), Wheel(3, 3L), Wheel(4, 3L)),
-            Seq(Wheel(1, 2L), Wheel(2, 2L), Wheel(3, 2L), Wheel(4, 2L)),
-            Seq(Wheel(1, 5L), Wheel(2, 5L), Wheel(3, 5L), Wheel(4, 5L))
-          )
-
-          val wheels2: Seq[Wheel] = Monad.Divergent.flatten(ms1)
-          wheels2 should contain only (
-            Wheel(1, 3L), Wheel(2, 3L), Wheel(3, 3L), Wheel(4, 3L),
-            Wheel(1, 2L), Wheel(2, 2L), Wheel(3, 2L), Wheel(4, 2L),
-            Wheel(1, 5L), Wheel(2, 5L), Wheel(3, 5L), Wheel(4, 5L)
-          )
-
-          val wheels3: Seq[Seq[Wheel]] = Monad.Divergent.run(Seq(
-            Car(3L, "foo"),
-            Car(2L, "bar"),
-            Car(5L, "baz")
-          ).map { car => ResolveWheels(car).map(_.map { wheel =>
-            Wheel(wheel.position, wheel.carId + 1)
-          }) })
-          wheels3 should contain only (
-            Seq(Wheel(1, 4L), Wheel(2, 4L), Wheel(3, 4L), Wheel(4, 4L)),
-            Seq(Wheel(1, 3L), Wheel(2, 3L), Wheel(3, 3L), Wheel(4, 3L)),
-            Seq(Wheel(1, 6L), Wheel(2, 6L), Wheel(3, 6L), Wheel(4, 6L))
-          )
-
-          val wheels4: Seq[Wheel] = Monad.Divergent.flatten(Seq(
-            Car(3L, "foo"),
-            Car(2L, "bar"),
-            Car(5L, "baz")
-          ).map { car => ResolveWheels(car).map(_.map { wheel =>
-            Wheel(wheel.position, wheel.carId + 1)
-          }) })
-          wheels4 should contain only (
-            Wheel(1, 4L), Wheel(2, 4L), Wheel(3, 4L), Wheel(4, 4L),
-            Wheel(1, 3L), Wheel(2, 3L), Wheel(3, 3L), Wheel(4, 3L),
-            Wheel(1, 6L), Wheel(2, 6L), Wheel(3, 6L), Wheel(4, 6L)
-          )
-        }
-      }
-
       locally { // default value
-        implicit val default: Monad.Default[Engine] =
-          Monad.Default(Engine(0L, 0L))
+        val default = Engine(0L, 0L)
 
         locally {
           val car = Car(3L, "foo")
           val engine = Engine(1001L, 3L)
 
-          val engine1: Option[Engine] = Monad.Divergent.run(Monad.Unit(engine))
-          engine1 shouldBe Some(engine)
+          val engine1: Engine = Monad.Unit(engine).runWithDefault(default)
+          engine1 shouldBe engine
 
-          val engine2: Engine =
-            Monad.Divergent.runWithDefault(Monad.Unit(engine))
+          val engine2: Engine = Monad.Unit(car).flatMap { _ =>
+            Monad.Unit(engine)
+          }.runWithDefault(default)
           engine2 shouldBe engine
 
-          val engine3: Option[Engine] =
-            Monad.Divergent.run(Monad.Unit(car).flatMap { _ =>
-              Monad.Unit(engine)
-            })
-          engine3 shouldBe Some(engine)
+          val engine3: Engine = Monad.Unit(car).flatMap { _ =>
+            Monad.Unit(engine)
+          }.map(identity).runWithDefault(default)
+          engine3 shouldBe engine
 
-          val engine4: Engine =
-            Monad.Divergent.runWithDefault(Monad.Unit(car).flatMap { _ =>
-              Monad.Unit(engine)
-            })
+          val engine4: Engine = (for {
+            c <- Monad.Unit(car)
+            e <- Monad.Unit(engine)
+          } yield(e)).runWithDefault(default)
           engine4 shouldBe engine
-
-          val engine5: Option[Engine] =
-            Monad.Divergent.run(Monad.Unit(car).flatMap { _ =>
-              Monad.Unit(engine)
-            }.map(identity))
-          engine5 shouldBe Some(engine)
-
-          val engine6: Engine =
-            Monad.Divergent.runWithDefault(Monad.Unit(car).flatMap { _ =>
-              Monad.Unit(engine)
-            }.map(identity))
-          engine6 shouldBe engine
-
-          val engine7: Option[Engine] = Monad.Divergent.run(for {
-            c <- Monad.Unit(car)
-            e <- Monad.Unit(engine)
-          } yield(e))
-          engine7 shouldBe Some(engine)
-
-          val engine8: Engine = Monad.Divergent.runWithDefault(for {
-            c <- Monad.Unit(car)
-            e <- Monad.Unit(engine)
-          } yield(e))
-          engine8 shouldBe engine
         }
 
         locally {
-          val engine1: Option[Engine] =
-            Monad.Divergent.run(ResolveEngine(Car(3L, "foo")))
-          engine1 shouldBe Some(Engine(1003L, 3L))
+          val engine1: Engine =
+            ResolveEngine(Car(3L, "foo")).runWithDefault(default)
+          engine1 shouldBe Engine(1003L, 3L)
 
           val engine2: Engine =
-            Monad.Divergent.runWithDefault(ResolveEngine(Car(3L, "foo")))
-          engine2 shouldBe Engine(1003L, 3L)
+            ResolveEngine(Car(2L, "bar")).runWithDefault(default)
+          engine2 shouldBe Engine(0L, 0L)
 
-          val engine3: Engine =
-            Monad.Divergent.runWithDefault(ResolveEngine(Car(2L, "bar")))
-          engine3 shouldBe Engine(0L, 0L)
+          val engine3: Engine = ResolveEngine(Car(3L, "foo")).flatMap { e =>
+            Monad.Unit(e)
+          }.runWithDefault(default)
+          engine3 shouldBe Engine(1003L, 3L)
 
-          val engine4: Option[Engine] =
-            Monad.Divergent.run(ResolveEngine(Car(3L, "foo")).flatMap { e =>
-              Monad.Unit(e)
-            })
-          engine4 shouldBe Some(Engine(1003L, 3L))
+          val engine4: Engine = ResolveEngine(Car(2L, "bar")).flatMap { e =>
+            Monad.Unit(e)
+          }.runWithDefault(default)
+          engine4 shouldBe Engine(0L, 0L)
 
-          val engine5: Engine =
-            Monad.Divergent.runWithDefault(ResolveEngine(Car(3L, "foo")).flatMap { e =>
-              Monad.Unit(e)
-            })
+          val engine5: Engine = ResolveEngine(Car(3L, "foo")).flatMap { e =>
+            Monad.Unit(e)
+          }.map(identity).runWithDefault(default)
           engine5 shouldBe Engine(1003L, 3L)
 
-          val engine6: Engine =
-            Monad.Divergent.runWithDefault(ResolveEngine(Car(2L, "bar")).flatMap { e =>
-              Monad.Unit(e)
-            })
+          val engine6: Engine = ResolveEngine(Car(2L, "bar")).flatMap { e =>
+            Monad.Unit(e)
+          }.map(identity).runWithDefault(default)
           engine6 shouldBe Engine(0L, 0L)
 
-          val engine7: Option[Engine] =
-            Monad.Divergent.run(ResolveEngine(Car(3L, "foo")).flatMap { e =>
-              Monad.Unit(e)
-            }.map(identity))
-          engine7 shouldBe Some(Engine(1003L, 3L))
-
-          val engine8: Engine =
-            Monad.Divergent.runWithDefault(ResolveEngine(Car(3L, "foo")).flatMap { e =>
-              Monad.Unit(e)
-            }.map(identity))
-          engine8 shouldBe Engine(1003L, 3L)
-
-          val engine9: Engine =
-            Monad.Divergent.runWithDefault(ResolveEngine(Car(2L, "bar")).flatMap { e =>
-              Monad.Unit(e)
-            }.map(identity))
-          engine9 shouldBe Engine(0L, 0L)
-
-          val engine10: Option[Engine] = Monad.Divergent.run(for {
+          val engine7: Engine = (for {
             e <- ResolveEngine(Car(3L, "foo"))
             e <- Monad.Unit(e)
-          } yield(e))
-          engine10 shouldBe Some(Engine(1003L, 3L))
+          } yield(e)).runWithDefault(default)
+          engine7 shouldBe Engine(1003L, 3L)
 
-          val engine11: Engine = Monad.Divergent.runWithDefault(for {
-            e <- ResolveEngine(Car(3L, "foo"))
-            e <- Monad.Unit(e)
-          } yield(e))
-          engine11 shouldBe Engine(1003L, 3L)
-
-          val engine12: Engine = Monad.Divergent.runWithDefault(for {
+          val engine8: Engine = (for {
             e <- ResolveEngine(Car(2L, "bar"))
             e <- Monad.Unit(e)
-          } yield(e))
-          engine12 shouldBe Engine(0L, 0L)
+          } yield(e)).runWithDefault(default)
+          engine8 shouldBe Engine(0L, 0L)
         }
       }
     }
@@ -1878,14 +1703,14 @@ class MonadSpec extends FunSpec with Matchers
       val m2 = Monad.Unit(Engine(0L, 0L)).flatMap { _ =>
         Monad.Unit(Crankshaft(1003L))
       }
-      val seq1: Seq[Monad[Crankshaft]] = Seq(m1, m2)
-      val seq2 = Seq(m1, m2)
+      val ms1: Seq[Monad[Crankshaft]] = Seq(m1, m2)
+      val ms2 = Seq(m1, m2)
 
-      Monad.Divergent.run(seq1) should contain only (
+      ms1.diverge.run should contain only (
         Crankshaft(1001L),
         Crankshaft(1003L)
       )
-      Monad.Divergent.run(seq2) should contain only (
+      ms2.diverge.run should contain only (
         Crankshaft(1001L),
         Crankshaft(1003L)
       )
@@ -1894,8 +1719,8 @@ class MonadSpec extends FunSpec with Matchers
         Monad.Unit(Engine(0L, 0L))
       }
       val m4 = Monad.Unit(Car(3L, "foo")).flatMap(ResolveEngine(_))
-      val seq3 = Seq(m3, m4)
-      Monad.Divergent.run(seq3) should contain only (
+      val ms3 = Seq(m3, m4)
+      ms3.diverge.run should contain only (
         Engine(0L, 0L),
         Engine(1003L, 3L)
       )
@@ -1905,7 +1730,7 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine1: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(3L, "foo"), c))
+          CountedResolveEngine(Car(3L, "foo"), c).run
         engine1 shouldBe Some(Engine(1003L, 3L))
         c.count shouldBe 1
       }
@@ -1913,7 +1738,7 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine2: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(2L, "bar"), c))
+          CountedResolveEngine(Car(2L, "bar"), c).run
         engine2 shouldBe None
         c.count shouldBe 1
       }
@@ -1925,7 +1750,7 @@ class MonadSpec extends FunSpec with Matchers
           CountedResolveEngine(Car(2L, "bar"), c),
           CountedResolveEngine(Car(5L, "baz"), c)
         )
-        val engines1: Seq[Engine] = Monad.Divergent.run(ms1)
+        val engines1: Seq[Engine] = ms1.diverge.run
         engines1 should contain only (Engine(1003L, 3L), Engine(1005L, 5L))
         c.count shouldBe 3
       }
@@ -1937,7 +1762,7 @@ class MonadSpec extends FunSpec with Matchers
           CountedResolveEngine(Car(2L, "bar"), c),
           CountedResolveEngine(Car(5L, "baz"), c)
         ).toSeq
-        val engines2: Seq[Engine] = Monad.Divergent.run(ms2)
+        val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe Array(Engine(1003L, 3L), Engine(1005L, 5L))
         c.count shouldBe 3
       }
@@ -1945,18 +1770,18 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine3: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(3L, "foo"), c).map { e =>
+          CountedResolveEngine(Car(3L, "foo"), c).map { e =>
             Engine(1002L, 5L)
-          })
+          }.run
         engine3 shouldBe Some(Engine(1002L, 5L))
         c.count shouldBe 1
       }
 
       locally {
         val c = new Counter
-        val engine4: Option[Engine] = Monad.Divergent.run(for {
+        val engine4: Option[Engine] = (for {
           e <- CountedResolveEngine(Car(3L, "foo"), c)
-        } yield(Engine(1002L, 5L)))
+        } yield(Engine(1002L, 5L))).run
         engine4 shouldBe Some(Engine(1002L, 5L))
         c.count shouldBe 1
       }
@@ -1964,18 +1789,18 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine5: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(2L, "bar"), c).map { e =>
+          CountedResolveEngine(Car(2L, "bar"), c).map { e =>
             Engine(1002L, 5L)
-          })
+          }.run
         engine5 shouldBe None
         c.count shouldBe 1
       }
 
       locally {
         val c = new Counter
-        val engine6: Option[Engine] = Monad.Divergent.run(for {
+        val engine6: Option[Engine] = (for {
           e <- CountedResolveEngine(Car(2L, "bar"), c)
-        } yield(Engine(1002L, 5L)))
+        } yield(Engine(1002L, 5L))).run
         engine6 shouldBe None
         c.count shouldBe 1
       }
@@ -1987,7 +1812,7 @@ class MonadSpec extends FunSpec with Matchers
           CountedResolveEngine(Car(2L, "bar"), c),
           CountedResolveEngine(Car(5L, "baz"), c)
         ).map { m => m.map { e => Engine(e.id + 1, e.carId + 1) } }
-        val engines3: Seq[Engine] = Monad.Divergent.run(ms3)
+        val engines3: Seq[Engine] = ms3.diverge.run
         engines3 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
         c.count shouldBe 3
       }
@@ -2001,7 +1826,7 @@ class MonadSpec extends FunSpec with Matchers
         ).map { car => for {
           e <- CountedResolveEngine(car, c)
         } yield(Engine(e.id + 1, e.carId + 1)) }
-        val engines4: Seq[Engine] = Monad.Divergent.run(ms4)
+        val engines4: Seq[Engine] = ms4.diverge.run
         engines4 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
         c.count shouldBe 3
       }
@@ -2009,19 +1834,19 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine3: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(3L, "foo"), c).flatMap { e =>
+          CountedResolveEngine(Car(3L, "foo"), c).flatMap { e =>
             Monad.Unit(Engine(1002L, 5L))
-          })
+          }.run
         engine3 shouldBe Some(Engine(1002L, 5L))
         c.count shouldBe 1
       }
 
       locally {
         val c = new Counter
-        val engine4: Option[Engine] = Monad.Divergent.run(for {
+        val engine4: Option[Engine] = (for {
           e <- CountedResolveEngine(Car(3L, "foo"), c)
           e <- Monad.Unit(Engine(1002L, 5L))
-        } yield(e))
+        } yield(e)).run
         engine4 shouldBe Some(Engine(1002L, 5L))
         c.count shouldBe 1
       }
@@ -2029,19 +1854,19 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine5: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(3L, "foo"), c).flatMap { e =>
+          CountedResolveEngine(Car(3L, "foo"), c).flatMap { e =>
             CountedResolveEngine(Car(5L, "baz"), c)
-          })
+          }.run
         engine5 shouldBe Some(Engine(1005L, 5L))
         c.count shouldBe 2
       }
 
       locally {
         val c = new Counter
-        val engine6: Option[Engine] = Monad.Divergent.run(for {
+        val engine6: Option[Engine] = (for {
           e <- CountedResolveEngine(Car(3L, "foo"), c)
           e <- CountedResolveEngine(Car(5L, "baz"), c)
-        } yield(e))
+        } yield(e)).run
         engine6 shouldBe Some(Engine(1005L, 5L))
         c.count shouldBe 2
       }
@@ -2049,19 +1874,19 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val engine7: Option[Engine] =
-          Monad.Divergent.run(CountedResolveEngine(Car(3L, "foo"), c).flatMap { e =>
+          CountedResolveEngine(Car(3L, "foo"), c).flatMap { e =>
             CountedResolveEngine(Car(2L, "bar"), c)
-          })
+          }.run
         engine7 shouldBe None
         c.count shouldBe 2
       }
 
       locally {
         val c = new Counter
-        val engine8: Option[Engine] = Monad.Divergent.run(for {
+        val engine8: Option[Engine] = (for {
           e <- CountedResolveEngine(Car(3L, "foo"), c)
           e <- CountedResolveEngine(Car(2L, "bar"), c)
-        } yield(e))
+        } yield(e)).run
         engine8 shouldBe None
         c.count shouldBe 2
       }
@@ -2073,7 +1898,7 @@ class MonadSpec extends FunSpec with Matchers
           CountedResolveEngine(Car(2L, "bar"), c),
           CountedResolveEngine(Car(5L, "baz"), c)
         ).map(_.flatMap { e => Monad.Unit(Engine(e.id + 1, e.carId + 1)) })
-        val engines3: Seq[Engine] = Monad.Divergent.run(ms3)
+        val engines3: Seq[Engine] = ms3.diverge.run
         engines3 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
         c.count shouldBe 3
       }
@@ -2088,7 +1913,7 @@ class MonadSpec extends FunSpec with Matchers
           e <- CountedResolveEngine(car, c)
           e <- Monad.Unit(Engine(e.id + 1, e.carId + 1))
         } yield(e) }
-        val engines4: Seq[Engine] = Monad.Divergent.run(ms4)
+        val engines4: Seq[Engine] = ms4.diverge.run
         engines4 shouldBe Array(Engine(1004L, 4L), Engine(1006L, 6L))
         c.count shouldBe 3
       }
@@ -2102,7 +1927,7 @@ class MonadSpec extends FunSpec with Matchers
         ).map(_.flatMap { e =>
           CountedResolveEngine(Car(e.carId+2, "dummy"), c)
         })
-        val engines5: Seq[Engine] = Monad.Divergent.run(ms5)
+        val engines5: Seq[Engine] = ms5.diverge.run
         engines5 shouldBe Array(Engine(1005L, 5L), Engine(1007L, 7L))
         c.count shouldBe 5
       }
@@ -2117,7 +1942,7 @@ class MonadSpec extends FunSpec with Matchers
           e <- CountedResolveEngine(car, c)
           e <- CountedResolveEngine(Car(e.carId+2, "dummy"), c)
         } yield(e) }
-        val engines6: Seq[Engine] = Monad.Divergent.run(ms6)
+        val engines6: Seq[Engine] = ms6.diverge.run
         engines6 shouldBe Array(Engine(1005L, 5L), Engine(1007L, 7L))
         c.count shouldBe 5
       }
@@ -2129,7 +1954,7 @@ class MonadSpec extends FunSpec with Matchers
         val ms6 = ms1.map { m => m.flatMap {
           e => CountedResolveEngine(Car(3L, "foo"), c)
         } }
-        val engines6: Seq[Engine] = Monad.Divergent.run(ms6)
+        val engines6: Seq[Engine] = ms6.diverge.run
         engines6 shouldBe empty
         c.count shouldBe 0
       }
@@ -2140,7 +1965,7 @@ class MonadSpec extends FunSpec with Matchers
           e <- m
           e <- CountedResolveEngine(Car(3L, "foo"), c)
         } yield(e) }
-        val engines7: Seq[Engine] = Monad.Divergent.run(ms7)
+        val engines7: Seq[Engine] = ms7.diverge.run
         engines7 shouldBe empty
         c.count shouldBe 0
       }
@@ -2148,7 +1973,7 @@ class MonadSpec extends FunSpec with Matchers
       locally {
         val c = new Counter
         val ms8 = Seq(Car(2L, "bar")).map(CountedResolveEngine(_, c))
-        val engines8: Seq[Engine] = Monad.Divergent.run(ms8)
+        val engines8: Seq[Engine] = ms8.diverge.run
         engines8 shouldBe empty
         c.count shouldBe 1
       }
@@ -2159,7 +1984,7 @@ class MonadSpec extends FunSpec with Matchers
         val ms13 = ms8.map { m => m.flatMap {
           e => CountedResolveEngine(Car(3L, "foo"), c)
         } }
-        val engines13: Seq[Engine] = Monad.Divergent.run(ms13)
+        val engines13: Seq[Engine] = ms13.diverge.run
         engines13 shouldBe empty
         c.count shouldBe 1
       }
@@ -2171,7 +1996,7 @@ class MonadSpec extends FunSpec with Matchers
           e <- m
           e <- CountedResolveEngine(Car(3L, "foo"), c)
         } yield(e) }
-        val engines14: Seq[Engine] = Monad.Divergent.run(ms14)
+        val engines14: Seq[Engine] = ms14.diverge.run
         engines14 shouldBe empty
         c.count shouldBe 1
       }

--- a/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
 
 class MonadSpec extends FunSpec with Matchers
     with OptionValues with Inside with Inspectors {
+  import Implicits._
   import Example._
 
   describe("Monad") {

--- a/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
@@ -23,7 +23,7 @@ class MonadSpec extends FunSpec with Matchers
         engines2 shouldBe Array(Engine(1001L, 3L))
 
         val ms3 = Array(Monad.Unit(Engine(1001L, 3L)))
-        val engines3: Seq[Engine] = Monad.run(ms3)
+        val engines3: Seq[Engine] = ms3.run
         engines3 shouldBe Array(Engine(1001L, 3L))
       }
 
@@ -55,7 +55,7 @@ class MonadSpec extends FunSpec with Matchers
           ResolveEngine(Car(2L, "bar")),
           ResolveEngine(Car(5L, "baz"))
         )
-        val engines3: Seq[Engine] = Monad.run(ms3)
+        val engines3: Seq[Engine] = ms3.run
         engines3 shouldBe Array(Engine(1003L, 3L), Engine(1005L, 5L))
       }
     }
@@ -591,16 +591,16 @@ class MonadSpec extends FunSpec with Matchers
       }
       val seq1: Seq[Monad[Crankshaft]] = Seq(m1, m2)
       assertTypeError("val r: Seq[Crankshaft] = seq1")
-      assertTypeError("val r: Seq[Crankshaft] = Monad.run(seq1)")
+      assertTypeError("val r: Seq[Crankshaft] = seq1.run")
       val seq2 = Seq(m1, m2)
       assertTypeError("val r: Seq[Crankshaft] = seq2")
-      assertTypeError("val r: Seq[Crankshaft] = Monad.run(seq2)")
+      assertTypeError("val r: Seq[Crankshaft] = seq2.run")
 
       val m3: Monad.FlatMapped[Crankshaft, Engine, Monad.Sig[Crankshaft, Null, Null, Null], _] = m1
       val m4:  Monad.FlatMapped[Crankshaft, Engine, Monad.Sig[Crankshaft, Null, Null, Null], _] = m2
       val seq3: Seq[ Monad.FlatMapped[Crankshaft, Engine, Monad.Sig[Crankshaft, Null, Null, Null], _]] = Seq(m3, m4)
       assertTypeError("val r: Seq[Crankshaft] = seq3")
-      assertTypeError("val r: Seq[Crankshaft] = Monad.run(seq3)")
+      assertTypeError("val r: Seq[Crankshaft] = seq3.run")
 
       val m5 = Monad.Unit(Car(3L, "foo")).flatMap { c =>
         Monad.Unit(Engine(0L, 0L))
@@ -608,13 +608,13 @@ class MonadSpec extends FunSpec with Matchers
       val m6 = Monad.Unit(Car(3L, "foo")).flatMap(ResolveEngine(_))
       val seq4 = Seq(m5, m6)
       assertTypeError("val r: Seq[Engine] = seq4")
-      assertTypeError("val r: Seq[Engine] = Monad.run(seq4)")
+      assertTypeError("val r: Seq[Engine] = seq4.run")
 
       val m7 = Monad.Unit(Car(3L, "foo")).flatMap { c => m5 }
       val m8 = Monad.Unit(Car(3L, "foo")).flatMap { c => m6 }
       val seq5 = Seq(m7, m8)
       assertTypeError("val r: Seq[Engine] = seq5")
-      assertTypeError("val r: Seq[Engine] = Monad.run(seq5)")
+      assertTypeError("val r: Seq[Engine] = seq5.run")
     }
 
     it("should satisfy monad laws") {
@@ -1103,7 +1103,7 @@ class MonadSpec extends FunSpec with Matchers
           CountedResolveEngine(Car(2L, "bar"), c),
           CountedResolveEngine(Car(5L, "baz"), c)
         )
-        val engines3: Seq[Engine] = Monad.run(ms3)
+        val engines3: Seq[Engine] = ms3.run
         engines3 shouldBe Array(Engine(1003L, 3L), Engine(1005L, 5L))
         c.count shouldBe 1
       }
@@ -1357,6 +1357,10 @@ class MonadSpec extends FunSpec with Matchers
         val ms2 = Array(Monad.Unit(Engine(1001L, 3L))).toSeq
         val engines2: Seq[Engine] = ms2.diverge.run
         engines2 shouldBe Array(Engine(1001L, 3L))
+
+        val ms3 = Array(Monad.Unit(Engine(1001L, 3L)))
+        val engines3: Seq[Engine] = ms3.diverge.run
+        engines3 shouldBe Array(Engine(1001L, 3L))
       }
 
       locally { // Resolve

--- a/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
+++ b/src/test/scala/com/github/tarao/bullet/MonadSpec.scala
@@ -548,11 +548,13 @@ class MonadSpec extends FunSpec with Matchers
         Monad.SingleValue(e)
       })
       assertTypeError("val engines: Seq[Engine] = ms1")
+      assertTypeError("val engines = ms1.run")
 
       val ms2 = Seq(ResolveEngine(Car(3L, "foo")).map { e =>
         Monad.SingleValue(e)
       })
       assertTypeError("val engines: Seq[Engine] = ms2")
+      assertTypeError("val engines = ms2.run")
     }
 
     it("should reject invalid monad type") {


### PR DESCRIPTION
Make explicit `run()`s be the default API.
